### PR TITLE
Redesign site banner

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -47,43 +47,34 @@ $('#main-nav').fadeIn();
 
 </script>
 
-<header class="nav-down">
-<div id="main-nav" class="navbar navbar-default navbar-fixed-top" role="navigation">
+<header class="site-header nav-down">
+<div id="main-nav" class="navbar navbar-default navbar-fixed-top site-banner" role="navigation">
+  <div class="container-fluid site-banner__inner">
+    <div class="site-banner__topbar">
+      <a class="site-banner__institution" href="https://www.sfu.ca/" aria-label="Simon Fraser University">
+        <img src="{{ site.url }}{{ site.baseurl }}/images/logopic/sfu_logo3.png" alt="Simon Fraser University">
+      </a>
 
-  <div class="container-fluid backg b"">
-	<div class="navbar-header navbar-right">
-	  <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-1" aria-expanded="false">
-		<span class="sr-only">Toggle navigation</span>
-		<span class="icon-bar"></span>
-		<span class="icon-bar"></span>
-		<span class="icon-bar"></span>
-	  </button>
-   
-   
-    <a href="https://www.sfu.ca/">
-      <img class="img_logo" src="{{ site.url }}{{ site.baseurl }}/images/logopic/sfu_logo3.png" style="height: 55px;">
-    </a>
-    <a href="{{ site.url }}{{ site.baseurl }}/">
-      <img class="img_logo2" src="{{ site.url }}{{ site.baseurl }}/images/logopic/gruvi_logo.png" style="height: 55px;">
-    </a>
-    
-    
-<div class="collapse navbar-collapse" id="navbar-collapse-1">
-	  <p align="right" style="padding-right: 10px;">
-                <a href="{{ site.url }}{{ site.baseurl }}/" style="color:#FFFFFF; text-shadow: 2px 2px 3px #606060;"><strong>HOME</strong></a></br>
-		<!-- <a href="{{ site.url }}{{ site.baseurl }}/vc_workshop_2022" style="color:#FFFFFF; text-shadow: 2px 2px 3px #606060;"><strong>SFU VC WORKSHOP 2022</strong></a></br> -->
-		<a href="{{ site.url }}{{ site.baseurl }}/people" style="color:#FFFFFF; text-shadow: 2px 2px 3px #606060;"><strong>GRUVIERS</strong></a></br>
-		<a href="{{ site.url }}{{ site.baseurl }}/publications" style="color:#FFFFFF; text-shadow: 2px 2px 3px #606060;"><strong>PUBLICATIONS</strong></a></br>
-		<a href="{{ site.url }}{{ site.baseurl }}/about" style="color:#FFFFFF; text-shadow: 2px 2px 3px #606060;"><strong>ABOUT</strong></a>
-             </p>
-	</div>
-</div>
+      <button type="button" class="navbar-toggle collapsed site-banner__toggle" data-toggle="collapse" data-target="#navbar-collapse-1" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+    </div>
 
-    
-	
-	
+    <div class="site-banner__main">
+      <a class="site-banner__brand" href="{{ site.url }}{{ site.baseurl }}/" aria-label="GrUVi home">
+        <img src="{{ site.url }}{{ site.baseurl }}/images/logopic/gruvi_logo.png" alt="GrUVi">
+      </a>
+    </div>
 
-</div> 
+    <div class="collapse navbar-collapse site-banner__nav" id="navbar-collapse-1">
+      <a href="{{ site.url }}{{ site.baseurl }}/" class="{% if page.url == '/' %}is-active{% endif %}">Home</a>
+      <a href="{{ site.url }}{{ site.baseurl }}/people" class="{% if page.url == '/people/' %}is-active{% endif %}">Gruviers</a>
+      <a href="{{ site.url }}{{ site.baseurl }}/publications" class="{% if page.url == '/publications/' %}is-active{% endif %}">Publications</a>
+      <a href="{{ site.url }}{{ site.baseurl }}/about" class="{% if page.url == '/about/' %}is-active{% endif %}">About</a>
+    </div>
+  </div>
 </div>
 </header>
-

--- a/css/main.scss
+++ b/css/main.scss
@@ -5,7 +5,7 @@
   width: 100%;
   background-size: auto 500px;
   background-image: url({{ site.url }}{{ site.baseurl }}/images/SFU_quadrangle.png);
-  background-position: 70% 0%; 
+  background-position: 70% 0%;
 }
     
 @import "bootstrap";
@@ -27,7 +27,7 @@ img { margin-bottom: 24px;
 
 
 body {
-	padding-top: 225px;
+	padding-top: 230px;
 }
 
 figcaption {
@@ -39,6 +39,252 @@ figcaption {
 
 
 /* Top navigation bar */
+
+.site-banner {
+  height: 230px;
+  min-height: 230px;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background-color: #16191d;
+  background-image:
+    linear-gradient(90deg, rgba(17, 18, 21, 0.94) 0%, rgba(29, 39, 46, 0.82) 44%, rgba(78, 36, 40, 0.44) 100%),
+    url({{ site.url }}{{ site.baseurl }}/images/SFU_quadrangle.png);
+  background-position: center 40%;
+  background-size: cover;
+  box-shadow: 0 12px 32px rgba(12, 25, 40, 0.22);
+}
+
+.site-banner:after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 1px;
+  content: "";
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.site-banner__inner {
+  position: relative;
+  display: block;
+  height: 230px;
+  min-height: 230px;
+  padding: 0 24px;
+}
+
+.site-banner__topbar,
+.site-banner__main {
+  position: relative;
+  z-index: 2;
+}
+
+.site-banner__topbar {
+  position: static;
+}
+
+.site-banner__institution {
+  position: absolute;
+  top: 20px;
+  left: 24px;
+  display: inline-flex;
+  align-items: center;
+  width: 112px;
+}
+
+.site-banner__institution img,
+.site-banner__brand img {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  border-radius: 0;
+  filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.26));
+}
+
+.site-banner__main {
+  position: absolute;
+  right: 24px;
+  bottom: 24px;
+  left: 24px;
+  display: flex;
+  align-items: center;
+}
+
+.site-banner__brand {
+  flex: 0 0 318px;
+  max-width: 318px;
+}
+
+.site-banner__nav {
+  position: absolute;
+  z-index: 3;
+  top: 29px;
+  right: 24px;
+  display: flex;
+  align-items: center;
+  gap: 26px;
+  width: auto;
+  max-width: 560px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.site-banner__nav a {
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  min-height: 28px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.site-banner__nav a:after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  content: "";
+  background: #89caec;
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform 160ms ease;
+}
+
+.site-banner__nav a:hover,
+.site-banner__nav a:focus,
+.site-banner__nav a.is-active {
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.site-banner__nav a:hover:after,
+.site-banner__nav a:focus:after,
+.site-banner__nav a.is-active:after {
+  transform: scaleX(1);
+}
+
+.site-banner__toggle {
+  position: absolute;
+  top: 18px;
+  right: 17px;
+  z-index: 4;
+  margin: 0;
+  border-color: rgba(255, 255, 255, 0.38);
+  background: rgba(17, 18, 21, 0.44);
+}
+
+.site-banner.navbar-default .site-banner__toggle {
+  margin: 0;
+  border-color: rgba(255, 255, 255, 0.38);
+  background: rgba(17, 18, 21, 0.44);
+}
+
+.site-banner.navbar-default .site-banner__toggle:hover,
+.site-banner.navbar-default .site-banner__toggle:focus {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.site-banner__toggle .icon-bar {
+  background-color: #ffffff;
+}
+
+@media (max-width: 767px) {
+  body {
+    padding-top: 202px;
+  }
+
+  .site-banner {
+    height: 202px;
+    min-height: 202px;
+    background-position: 57% 50%;
+  }
+
+  .site-banner__inner {
+    height: 202px;
+    min-height: 202px;
+    padding: 0 17px;
+  }
+
+  .site-banner__institution {
+    top: 16px;
+    left: 17px;
+    width: 96px;
+  }
+
+  .site-banner__main {
+    right: 17px;
+    bottom: 18px;
+    left: 17px;
+    align-items: flex-end;
+  }
+
+  .site-banner__brand {
+    flex-basis: 248px;
+    width: 248px;
+    max-width: 72vw;
+  }
+
+  .site-banner__nav {
+    position: absolute;
+    top: 62px;
+    right: 17px;
+    left: auto;
+    display: none;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    width: 188px;
+    max-width: none;
+    margin: 0;
+    padding: 5px;
+    border: 1px solid rgba(229, 240, 248, 0.25);
+    border-radius: 8px;
+    background: rgba(17, 18, 21, 0.96);
+    box-shadow: 0 16px 34px rgba(0, 0, 0, 0.24);
+  }
+
+  .site-banner__nav.collapse.in {
+    display: flex !important;
+  }
+
+  .site-banner__nav a {
+    display: flex;
+    justify-content: flex-start;
+    min-height: 30px;
+    padding: 0 12px;
+    border-radius: 6px;
+  }
+
+  .site-banner__nav a:after {
+    display: none;
+  }
+
+  .site-banner__nav a:hover,
+  .site-banner__nav a:focus,
+  .site-banner__nav a.is-active {
+    background: rgba(255, 255, 255, 0.12);
+  }
+}
+
+@media (min-width: 768px) {
+  .site-banner__nav.collapse {
+    display: flex !important;
+    height: auto !important;
+  }
+}
 
 p {
 	align: justify;
@@ -277,4 +523,3 @@ table, table11 {
       overflow: visible;
    }
 }
-


### PR DESCRIPTION
## Summary
- redesign the fixed site banner using the existing original SFU logo and GrUVi logo over the campus image
- remove the extra unsourced tagline/research-area copy from the banner
- replace the boxed navigation buttons with cleaner text links and an underline active/hover state
- keep the mobile hamburger, with a compact dropdown only when opened

## Verification
- rebuilt the full site preview at `http://localhost:8772/`
- checked `/`, `/publications/`, `/people/`, and `/about/` all return `200`
- captured desktop, mobile, and expanded-mobile-menu screenshots
- ran `git diff --check`
